### PR TITLE
bump `click2cwl==0.5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ license = "Apache-2.0"
 dependencies = [
     "click",
     "click-option-group",
-    # FIXME: pin of 'click2cwl>0.4.0' to include param type fix (https://github.com/Terradue/click2cwl/pull/11)
-    "click2cwl @ git+https://github.com/Terradue/click2cwl.git@af5dccd01952f715b41ed91640afa6180fefecfd",
+    "click2cwl==0.5.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Replace the temporary `click2cwl` version including https://github.com/Terradue/click2cwl/pull/11 to the released version containing it. 